### PR TITLE
cleanup even if a callback throws (fixes #1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+language: node_js
+node_js:
+  - '0.10'
+  - '0.12'
+  - '4'
+  - '5'
+  - '6'

--- a/inflight.js
+++ b/inflight.js
@@ -19,26 +19,21 @@ function makeres (key) {
     var cbs = reqs[key]
     var len = cbs.length
     var args = slice(arguments)
-    var err = null
-    for (var i = 0; i < len; i++) {
-      try {
+    try {
+      for (var i = 0; i < len; i++) {
         cbs[i].apply(null, args)
-      } catch(e) {
-        err = e
       }
-    }
-    if (cbs.length > len) {
-      // added more in the interim.
-      // de-zalgo, just in case, but don't call again.
-      cbs.splice(0, len)
-      process.nextTick(function () {
-        RES.apply(null, args)
-      })
-    } else {
-      delete reqs[key]
-    }
-    if (err) {
-      throw err
+    } finally {
+      if (cbs.length > len) {
+        // added more in the interim.
+        // de-zalgo, just in case, but don't call again.
+        cbs.splice(0, len)
+        process.nextTick(function () {
+          RES.apply(null, args)
+        })
+      } else {
+        delete reqs[key]
+      }
     }
   })
 }

--- a/inflight.js
+++ b/inflight.js
@@ -19,8 +19,13 @@ function makeres (key) {
     var cbs = reqs[key]
     var len = cbs.length
     var args = slice(arguments)
+    var err = null
     for (var i = 0; i < len; i++) {
-      cbs[i].apply(null, args)
+      try {
+        cbs[i].apply(null, args)
+      } catch(e) {
+        err = e
+      }
     }
     if (cbs.length > len) {
       // added more in the interim.
@@ -31,6 +36,9 @@ function makeres (key) {
       })
     } else {
       delete reqs[key]
+    }
+    if (err) {
+      throw err
     }
   })
 }

--- a/test.js
+++ b/test.js
@@ -95,3 +95,57 @@ test('parameters', function (t) {
     a(1, 2, 3)
   })
 })
+
+test('throw (a)', function (t) {
+  var calleda = false
+  var a = inf('throw', function (k) {
+    t.notOk(calleda)
+    calleda = true
+    throw new Error('throw from a')
+  })
+  t.ok(a, 'first returned cb function')
+
+  var calledb = false
+  var b = inf('throw', function (k) {
+    t.notOk(calledb)
+    calledb = true
+  })
+  t.notOk(b, 'second should get falsey inflight response')
+
+  setTimeout(function () {
+    try {
+      a()
+    } catch(e) {
+      t.ok(calleda)
+      t.ok(calledb)
+      t.end()
+    }
+  })
+})
+
+test('throw (b)', function (t) {
+  var calleda = false
+  var a = inf('throw', function (k) {
+    t.notOk(calleda)
+    calleda = true
+  })
+  t.ok(a, 'first returned cb function')
+
+  var calledb = false
+  var b = inf('throw', function (k) {
+    t.notOk(calledb)
+    calledb = true
+    throw new Error('throw from b')
+  })
+  t.notOk(b, 'second should get falsey inflight response')
+
+  setTimeout(function () {
+    try {
+      a()
+    } catch(e) {
+      t.ok(calleda)
+      t.ok(calledb)
+      t.end()
+    }
+  })
+})


### PR DESCRIPTION
I'm not sure if this is the proper way to handle an error thrown by an inflight callback, but something needs to happen to cleanup after the throw.